### PR TITLE
update config.serve_static_assets to config.serve_static_files

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.config.serve_static_files = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = true
+  config.config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
Currently getting this warning when running it manually

```
(AT BEGINNING OF FILE)
I1128 19:08:19.933274  3742 exec.cpp:162] Version: 1.5.0
I1128 19:08:19.947046  3750 exec.cpp:237] Executor registered on agent 398657d7-1a33-4809-ad18-217d8bcd0432-S5
I1128 19:08:19.947947  3745 executor.cpp:120] Registered docker executor on 10.0.2.173
I1128 19:08:19.948096  3747 executor.cpp:160] Starting task tweeter.59f6e2fb-d46f-11e7-ac58-02a9f91c45e1
DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly. (called from block in <top (required)> at /usr/src/app/config/environments/production.rb:16)
DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly. (called from block in <top (required)> at /usr/src/app/config/environments/production.rb:16)
[2017-11-28 19:08:37] INFO  WEBrick 1.3.1
[2017-11-28 19:08:37] INFO  ruby 2.3.3 (2016-11-21) [x86_64-linux]
[2017-11-28 19:08:37] INFO  WEBrick::HTTPServer#start: pid=14 port=3000
```